### PR TITLE
Fix for Installation Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "readmeFilename": "README.markdown",
   "gitHead": "55151daed59ca2612001e493c37f2fa8407d6be6",
   "dependencies": {
-    "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    "eve": "git+https://github.com/adobe-webplatform/eve.git#eef80ed"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raphael",
-  "version": "2.1.4b",
+  "version": "2.2.0-c",
   "description": "JavaScript Vector Library",
   "main": "raphael.amd.js",
   "scripts": {


### PR DESCRIPTION
Since the connection to Github must use SSH the installation of TUI-Editor failed.
The connection to git://github.com/adobe-webplatform/eve.git#eef80ed timed out.

This fixes the Errors. I'm now able to install TUI-Editor via yarn.