### PR TITLE
fix deprecated URL for dependency 'eve'

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "readmeFilename": "README.markdown",
   "gitHead": "55151daed59ca2612001e493c37f2fa8407d6be6",
   "dependencies": {
-    "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    "eve": "git@github.com:adobe-webplatform/eve.git#eef80ed"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
GitHub is deprecating the unencrypted git:// protocol, it will be completely disabled in March 2022. I changed 'eve' to use an SSH url instead. Tested using `npm install`.